### PR TITLE
Update Makefile.PL

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -28,7 +28,8 @@ if ($ENV{MPFR_LIBS}) {
 use_ppport;
 use_xshelper;
 cc_warnings;
-cc_libs 'mpfr';
+#cc_libs 'mpfr';
+cc_libs '-lmpfr -lgmp';
 cc_src_paths 'xs';
 author_tests 'xt';
 auto_set_repository;


### PR DESCRIPTION
 Hi Daisuke Maki,
 i'm new to Pull request (parecipating to PullRequest Challenge).
Trying to install the module on strawberry for Windows, there was error on compilation:

C:\STRAWB~1\c\lib\libmpfr.a(clear.o):(.text+0x1e): undefined reference to `__gmp_get_memory_functions'
C:\STRAWB~1\c\lib\libmpfr.a(mul.o):(.text+0x4e4): undefined reference to `__gmpn_mul'
C:\STRAWB~1\c\lib\libmpfr.a(mul.o):(.text+0x517): undefined reference to `__gmpn_lshift'
C:\STRAWB~1\c\lib\libmpfr.a(mul.o):(.text+0x7e7): undefined reference to `__gmpn_lshift'


Looking at mpfr.org i've found this faq:

[from http://www.mpfr.org/faq.html#undef_ref1]
5. When I link my program with MPFR, I get undefined reference to __gmpXXXX.

    Link your program with GMP. Assuming that your program is foo.c, you should link it using: 
		cc link.c -lmpfr -lgmp 
	MPFR library reference (-lmpfr) should be before GMP's one (-lgmp). Another solution is, with GNU ld, to give all the libraries inside a group: 
		gcc link.c -Wl,--start-group libgmp.a libmpfr.a -Wl,--end-group 
	See INSTALL file and ld manual for more details.

I've touched Makefile.pl and added gmp library.

Seems that the Makefile.pl is different in gitHub and in Cpan.

Have a nice day and CIAO
Ulderico 

PS: excuse for my english 
